### PR TITLE
LP1378355 - Pass the value of --defaults-group-suffix to xtrabackup duri...

### DIFF
--- a/mysql-test/lib/My/ConfigFactory.pm
+++ b/mysql-test/lib/My/ConfigFactory.pm
@@ -240,6 +240,8 @@ my @mysqld_rules=
  { 'port' => \&fix_port },
  # galera base_port and port used during SST
  { '#galera_port' => \&fix_port },
+ # Galera uses base_port + 1 for IST, so we do not use it for things such as SST
+ { '#ist_port' => \&fix_port },
  { '#sst_port' => \&fix_port },
  { '#memcached_port' => \&fix_port },
  { 'socket' => \&fix_socket },

--- a/mysys_ssl/my_default.cc
+++ b/mysys_ssl/my_default.cc
@@ -114,6 +114,7 @@ static my_bool defaults_already_read= FALSE;
 /* The only purpose of this global array is to hold full name of my.cnf
  * which seems to be otherwise unavailable */
 char wsrep_defaults_file[FN_REFLEN + 10]={0,};
+char wsrep_defaults_group_suffix[FN_REFLEN]={0,};
 #endif /* WITH_WREP */
 /* Set to TRUE, if --no-defaults is found. */
 static my_bool found_no_defaults= FALSE;
@@ -539,6 +540,13 @@ int get_defaults_options(int argc, char **argv,
     if (!*group_suffix && is_prefix(*argv, "--defaults-group-suffix="))
     {
       *group_suffix= *argv + sizeof("--defaults-group-suffix=")-1;
+
+#ifdef WITH_WSREP
+      /* make sure we do this only once - for top-level file */
+      if ('\0' == wsrep_defaults_group_suffix[0])
+        strncpy(wsrep_defaults_group_suffix, *group_suffix, sizeof(wsrep_defaults_group_suffix) - 1);
+#endif /* WITH_WSREP */
+
       argc--;
       default_option_count ++;
       continue;

--- a/mysys_ssl/my_default.cc
+++ b/mysys_ssl/my_default.cc
@@ -114,7 +114,7 @@ static my_bool defaults_already_read= FALSE;
 /* The only purpose of this global array is to hold full name of my.cnf
  * which seems to be otherwise unavailable */
 char wsrep_defaults_file[FN_REFLEN + 10]={0,};
-char wsrep_defaults_group_suffix[FN_REFLEN]={0,};
+char wsrep_defaults_group_suffix[FN_EXTLEN]={0,};
 #endif /* WITH_WREP */
 /* Set to TRUE, if --no-defaults is found. */
 static my_bool found_no_defaults= FALSE;

--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -44,6 +44,10 @@ case "$1" in
         readonly WSREP_SST_OPT_CONF="$2"
         shift
         ;;
+    '--defaults-group-suffix')
+        readonly WSREP_SST_OPT_CONF_SUFFIX="$2"
+        shift
+        ;;
     '--host')
         readonly WSREP_SST_OPT_HOST="$2"
         shift

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -557,8 +557,8 @@ fi
 
 INNOEXTRA=""
 INNOAPPLY="${INNOBACKUPEX_BIN} $disver $iapts --apply-log \$rebuildcmd \${DATA} &>\${DATA}/innobackup.prepare.log"
-INNOMOVE="${INNOBACKUPEX_BIN} --defaults-file=${WSREP_SST_OPT_CONF} $disver $impts  --move-back --force-non-empty-directories \${DATA} &>\${DATA}/innobackup.move.log"
-INNOBACKUP="${INNOBACKUPEX_BIN} --defaults-file=${WSREP_SST_OPT_CONF} $disver $iopts \$tmpopts \$INNOEXTRA --galera-info --stream=\$sfmt \$itmpdir 2>\${DATA}/innobackup.backup.log"
+INNOMOVE="${INNOBACKUPEX_BIN} --defaults-file=${WSREP_SST_OPT_CONF} --defaults-group=mysqld${WSREP_SST_OPT_CONF_SUFFIX} $disver $impts  --move-back --force-non-empty-directories \${DATA} &>\${DATA}/innobackup.move.log"
+INNOBACKUP="${INNOBACKUPEX_BIN} --defaults-file=${WSREP_SST_OPT_CONF} --defaults-group=mysqld${WSREP_SST_OPT_CONF_SUFFIX} $disver $iopts \$tmpopts \$INNOEXTRA --galera-info --stream=\$sfmt \$itmpdir 2>\${DATA}/innobackup.backup.log"
 
 if [ "$WSREP_SST_OPT_ROLE" = "donor" ]
 then
@@ -879,7 +879,7 @@ then
 
         if [[ $incremental -eq 1 ]];then 
             # Added --ibbackup=xtrabackup_55 because it fails otherwise citing connection issues.
-            INNOAPPLY="${INNOBACKUPEX_BIN} $disver --defaults-file=${WSREP_SST_OPT_CONF} \
+            INNOAPPLY="${INNOBACKUPEX_BIN} $disver --defaults-file=${WSREP_SST_OPT_CONF} --defaults-group=mysqld${WSREP_SST_OPT_CONF_SUFFIX} \
                 --ibbackup=xtrabackup_56 --apply-log $rebuildcmd --redo-only $BDATA --incremental-dir=${DATA} &>>${BDATA}/innobackup.prepare.log"
         fi
 

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -27,12 +27,14 @@
 #include <cstdlib>
 
 extern const char wsrep_defaults_file[];
+extern const char wsrep_defaults_group_suffix[];
 
 #define WSREP_SST_OPT_ROLE     "--role"
 #define WSREP_SST_OPT_ADDR     "--address"
 #define WSREP_SST_OPT_AUTH     "--auth"
 #define WSREP_SST_OPT_DATA     "--datadir"
 #define WSREP_SST_OPT_CONF     "--defaults-file"
+#define WSREP_SST_OPT_CONF_SUFFIX "--defaults-group-suffix"
 #define WSREP_SST_OPT_PARENT   "--parent"
 #define WSREP_SST_OPT_BINLOG   "--binlog"
 
@@ -459,10 +461,11 @@ static ssize_t sst_prepare_other (const char*  method,
                  WSREP_SST_OPT_AUTH" '%s' "
                  WSREP_SST_OPT_DATA" '%s' "
                  WSREP_SST_OPT_CONF" '%s' "
+                 WSREP_SST_OPT_CONF_SUFFIX" '%s' "
                  WSREP_SST_OPT_PARENT" '%d'"
                  " %s '%s' ",
                  method, addr_in, (sst_auth_real) ? sst_auth_real : "",
-                 sst_dir, wsrep_defaults_file, (int)getpid(),
+                 sst_dir, wsrep_defaults_file, wsrep_defaults_group_suffix, (int)getpid(),
                  binlog_opt, binlog_opt_val);
   my_free(binlog_opt_val);
 
@@ -759,10 +762,11 @@ static int sst_donate_mysqldump (const char*         addr,
               WSREP_SST_OPT_LPORT" '%u' "
               WSREP_SST_OPT_SOCKET" '%s' "
               WSREP_SST_OPT_CONF" '%s' "
+              WSREP_SST_OPT_CONF_SUFFIX" '%s' "
               WSREP_SST_OPT_GTID" '%s:%lld'"
               "%s",
               user, pswd, host, port, mysqld_port, mysqld_unix_port,
-              wsrep_defaults_file, uuid_str,
+              wsrep_defaults_file, wsrep_defaults_group_suffix, uuid_str,
               (long long)seqno, bypass ? " "WSREP_SST_OPT_BYPASS : "");
 
     WSREP_DEBUG("Running: '%s'", cmd_str);
@@ -1001,11 +1005,12 @@ static int sst_donate_other (const char*   method,
                  WSREP_SST_OPT_SOCKET" '%s' "
                  WSREP_SST_OPT_DATA" '%s' "
                  WSREP_SST_OPT_CONF" '%s' "
+                 WSREP_SST_OPT_CONF_SUFFIX" '%s' "
                  " %s '%s' "
                  WSREP_SST_OPT_GTID" '%s:%lld'"
                  "%s",
                  method, addr, sst_auth_real, mysqld_unix_port,
-                 mysql_real_data_home, wsrep_defaults_file,
+                 mysql_real_data_home, wsrep_defaults_file, wsrep_defaults_group_suffix,
                  binlog_opt, binlog_opt_val,
                  uuid, (long long) seqno,
                  bypass ? " "WSREP_SST_OPT_BYPASS : "");

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -762,11 +762,10 @@ static int sst_donate_mysqldump (const char*         addr,
               WSREP_SST_OPT_LPORT" '%u' "
               WSREP_SST_OPT_SOCKET" '%s' "
               WSREP_SST_OPT_CONF" '%s' "
-              WSREP_SST_OPT_CONF_SUFFIX" '%s' "
               WSREP_SST_OPT_GTID" '%s:%lld'"
               "%s",
               user, pswd, host, port, mysqld_port, mysqld_unix_port,
-              wsrep_defaults_file, wsrep_defaults_group_suffix, uuid_str,
+              wsrep_defaults_file, uuid_str,
               (long long)seqno, bypass ? " "WSREP_SST_OPT_BYPASS : "");
 
     WSREP_DEBUG("Running: '%s'", cmd_str);


### PR DESCRIPTION
...ng SST

MTR starts all nodes with a shared my.cnf file with individual sections per-server. In order for xtrabackup SST to work in such an environment, xtrabackup must be passed the name of the section so that it can retrieve the innodb parameters from it.

This option was added to xtrabackup version 2.0.1 in  Jul 07 2012, so this change will break compatibility with  older versions of xtrabackup.

MySQL provides the name of the section as a suffix, e.g. ".2" and xtrabackup requires the full name, e.g. "mysqld.2". So the bash script will concatenate mysqld to .2 to produce the format required by xtrabackup. If there is no dedicated section, and no suffix, the default will be "mysqld".
