### PR TITLE
codership/mysql-wsrep#67 - total order isolation for FLUSH

### DIFF
--- a/mysql-test/suite/galera/r/galera_flush.result
+++ b/mysql-test/suite/galera/r/galera_flush.result
@@ -1,0 +1,32 @@
+FLUSH DES_KEY_FILE;
+wsrep_last_committed_diff
+1
+FLUSH HOSTS;
+wsrep_last_committed_diff
+1
+SET GLOBAL wsrep_replicate_myisam = TRUE;
+INSERT INTO mysql.user VALUES('localhost','user1',PASSWORD('pass1'), 'Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','','','','',0,0,0,0,'mysql_native_password','','N');
+FLUSH PRIVILEGES;
+DELETE FROM mysql.user WHERE user = 'user1';
+SET GLOBAL wsrep_replicate_myisam = FALSE;
+FLUSH PRIVILEGES;
+FLUSH QUERY CACHE;
+wsrep_last_committed_diff
+1
+FLUSH STATUS;
+wsrep_last_committed_diff
+1
+FLUSH USER_RESOURCES;
+wsrep_last_committed_diff
+1
+CREATE TABLE t1 (f1 INTEGER);
+FLUSH LOGS;
+FLUSH TABLES WITH READ LOCK;
+UNLOCK TABLES;
+FLUSH TABLES t1 WITH READ LOCK;
+UNLOCK TABLES;
+FLUSH TABLES t1 FOR EXPORT;
+UNLOCK TABLES;
+wsrep_last_committed_diff
+1
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_flush-master.opt
+++ b/mysql-test/suite/galera/t/galera_flush-master.opt
@@ -1,0 +1,1 @@
+--query_cache_type=1 --query_cache_size=1000000

--- a/mysql-test/suite/galera/t/galera_flush.test
+++ b/mysql-test/suite/galera/t/galera_flush.test
@@ -1,0 +1,107 @@
+#
+# Test that various FLUSH commands are replicated. Whenever possible, check the slave for the effects.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_perfschema.inc
+--source include/have_query_cache.inc
+
+#
+# The following FLUSH statements should be replicated
+#
+
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+--connection node_1
+FLUSH DES_KEY_FILE;
+--connection node_2
+--let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+--disable_query_log
+--eval SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
+--enable_query_log
+
+
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+--connection node_1
+FLUSH HOSTS;
+--connection node_2
+--let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+--disable_query_log
+--eval SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
+--enable_query_log
+
+--connection node_1
+SET GLOBAL wsrep_replicate_myisam = TRUE;
+INSERT INTO mysql.user VALUES('localhost','user1',PASSWORD('pass1'), 'Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','','','','',0,0,0,0,'mysql_native_password','','N');
+FLUSH PRIVILEGES;
+--connect node_2a, 127.0.0.1, user1, pass1, test, $NODE_MYPORT_2
+--connection node_1
+DELETE FROM mysql.user WHERE user = 'user1';
+SET GLOBAL wsrep_replicate_myisam = FALSE;
+FLUSH PRIVILEGES;
+
+
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+--connection node_1
+FLUSH QUERY CACHE;
+--connection node_2
+--let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+--disable_query_log
+--eval SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
+--enable_query_log
+
+
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+--connection node_1
+FLUSH STATUS;
+
+--connection node_2
+--let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+--disable_query_log
+--eval SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
+--enable_query_log
+
+
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+--connection node_1
+FLUSH USER_RESOURCES;
+--connection node_2
+--let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+--disable_query_log
+--eval SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
+--enable_query_log
+
+
+#
+# The following statements should not be replicated: FLUSH LOGS, FLUSH TABLES
+#
+
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER);
+
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_1
+FLUSH LOGS;
+FLUSH TABLES WITH READ LOCK;
+UNLOCK TABLES;
+FLUSH TABLES t1 WITH READ LOCK;
+UNLOCK TABLES;
+FLUSH TABLES t1 FOR EXPORT;
+UNLOCK TABLES;
+
+--connection node_2
+--let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+--disable_query_log
+--eval SELECT $wsrep_last_committed_after = $wsrep_last_committed_before AS wsrep_last_committed_diff;
+--enable_query_log
+
+--connection node_1
+DROP TABLE t1;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4564,6 +4564,21 @@ end_with_restore_list:
       break;
     }
 
+#ifdef WITH_WSREP
+    if (lex->type & (
+            REFRESH_GRANT            |
+            REFRESH_HOSTS            |
+            REFRESH_DES_KEY_FILE     |
+#ifdef HAVE_QUERY_CACHE
+            REFRESH_QUERY_CACHE_FREE |
+#endif /* HAVE_QUERY_CACHE */
+            REFRESH_STATUS           |
+            REFRESH_USER_RESOURCES))
+    {
+      WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+    }
+#endif /* WITH_WSREP*/
+
     /*
       reload_acl_and_cache() will tell us if we are allowed to write to the
       binlog or not.


### PR DESCRIPTION
The following FLUSH commands are now executed under total
order isolation:
- FLUSH DES_KEY_FILE
- FLUSH HOSTS
- FLUSH PRIVILEGES
- FLUSH QUERY CACHE
- FLUSH STATUS
- FLUSH USER_RESOURCES
