### PR TITLE
Refs codership/mysql-wsrep#33

### DIFF
--- a/scripts/wsrep_sst_mysqldump.sh
+++ b/scripts/wsrep_sst_mysqldump.sh
@@ -54,7 +54,7 @@ then
 fi
 
 # Check client version
-CLIENT_MINOR=$(mysql --version | cut -d ' ' -f 6 | cut -d '.' -f 2)
+CLIENT_MINOR=$($MYSQL_CLIENT --version | cut -d ' ' -f 6 | cut -d '.' -f 2)
 if [ $CLIENT_MINOR -lt "6" ]
 then
     $MYSQL_CLIENT --version >&2

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -178,12 +178,13 @@ SET(SQL_EXPORTED_SOURCES ${SQL_SHARED_SOURCES} PARENT_SCOPE)
 
 IF(WITH_WSREP)
  SET(WSREP_SOURCES
+   wsrep_utils.cc
+   wsrep_xid.cc
    wsrep_check_opts.cc
    wsrep_hton.cc
    wsrep_mysqld.cc
    wsrep_notify.cc
    wsrep_sst.cc
-   wsrep_utils.cc
    wsrep_var.cc
    wsrep_binlog.cc
    wsrep_applier.cc

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -33,6 +33,10 @@
 #include <string>
 #include <my_stacktrace.h>
 
+#ifdef WITH_WSREP
+#include "wsrep_xid.h"
+#endif /* WITH_WSREP */
+
 using std::max;
 using std::min;
 using std::string;
@@ -6457,7 +6461,7 @@ TC_LOG::enum_result MYSQL_BIN_LOG::commit(THD *thd, bool all)
   binlog_cache_mngr *cache_mngr= thd_get_cache_mngr(thd);
 #ifdef WITH_WSREP
   my_xid xid= (wsrep_is_wsrep_xid(&thd->transaction.xid_state.xid) ?
-               wsrep_xid_seqno(&thd->transaction.xid_state.xid) :
+               wsrep_xid_seqno(thd->transaction.xid_state.xid) :
                thd->transaction.xid_state.xid.get_my_xid());
 #else
   my_xid xid= thd->transaction.xid_state.xid.get_my_xid();
@@ -7277,16 +7281,15 @@ int MYSQL_BIN_LOG::recover(IO_CACHE *log, Format_description_log_event *fdle,
     Read current wsrep position from storage engines to have consistent
     end position for binlog scan.
   */
-  XID xid;
-  memset(&xid, 0, sizeof(xid));
-  xid.formatID= -1;
-  wsrep_get_SE_checkpoint(&xid);
+  wsrep_uuid_t uuid;
+  wsrep_seqno_t seqno;
+  wsrep_get_SE_checkpoint(uuid, seqno);
   char uuid_str[40];
-  wsrep_uuid_print(wsrep_xid_uuid(&xid), uuid_str, sizeof(uuid_str));
+  wsrep_uuid_print(&uuid, uuid_str, sizeof(uuid_str));
   WSREP_INFO("Binlog recovery, found wsrep position %s:%lld", uuid_str,
-             (long long)wsrep_xid_seqno(&xid));
-  const wsrep_seqno_t last_xid_seqno= wsrep_xid_seqno(&xid);
-  wsrep_seqno_t cur_xid_seqno=WSREP_SEQNO_UNDEFINED;
+             (long long)seqno);
+  const wsrep_seqno_t last_xid_seqno= seqno;
+  wsrep_seqno_t cur_xid_seqno= WSREP_SEQNO_UNDEFINED;
 #endif /* WITH_WSREP */
 
 

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -62,6 +62,7 @@ inline double log2(double x)
 #endif
 #ifdef WITH_WSREP
 #include "wsrep_mysqld.h"
+#include "wsrep_xid.h"
 #endif
 /*
   While we have legacy_db_type, we have this array to
@@ -1838,7 +1839,7 @@ static my_bool xarecover_handlerton(THD *unused, plugin_ref plugin,
       {
 #ifdef WITH_WSREP
         my_xid x=(wsrep_is_wsrep_xid(&info->list[i]) ?
-                  wsrep_xid_seqno(&info->list[i]) :
+                  wsrep_xid_seqno(info->list[i]) :
                   info->list[i].get_my_xid());
 #else
         my_xid x=info->list[i].get_my_xid();

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -110,6 +110,7 @@ using std::min;
 #ifdef WITH_WSREP
 #include "wsrep_mysqld.h"
 #include "wsrep_thd.h"
+#include "wsrep_binlog.h"
 static void wsrep_mysql_parse(THD *thd, char *rawbuf, uint length,
                               Parser_state *parser_state);
 #endif /* WITH_WSREP */

--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013 Codership Oy <info@codership.com>
+/* Copyright (C) 2013-2015 Codership Oy <info@codership.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -13,11 +13,13 @@
    with this program; if not, write to the Free Software Foundation, Inc.,
    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
+#include "wsrep_applier.h"
+
 #include "wsrep_priv.h"
 #include "wsrep_binlog.h" // wsrep_dump_rbr_buf()
+#include "wsrep_xid.h"
 
 #include "log_event.h" // class THD, EVENT_LEN_OFFSET, etc.
-#include "wsrep_applier.h"
 #include "debug_sync.h"
 
 /*
@@ -143,7 +145,7 @@ static wsrep_cb_status_t wsrep_apply_events(THD*        thd,
     thd->server_id = ev->server_id; // use the original server id for logging
     thd->set_time();                // time the query
     wsrep_xid_init(&thd->transaction.xid_state.xid,
-                   &thd->wsrep_trx_meta.gtid.uuid,
+                   thd->wsrep_trx_meta.gtid.uuid,
                    thd->wsrep_trx_meta.gtid.seqno);
     thd->lex->current_select= 0;
     if (!ev->when.tv_sec)

--- a/sql/wsrep_applier.h
+++ b/sql/wsrep_applier.h
@@ -16,7 +16,7 @@
 #ifndef WSREP_APPLIER_H
 #define WSREP_APPLIER_H
 
-#include <sys/types.h>
+#include "../wsrep/wsrep_api.h"
 
 /* wsrep callback prototypes */
 

--- a/sql/wsrep_hton.cc
+++ b/sql/wsrep_hton.cc
@@ -1,4 +1,4 @@
-/* Copyright 2008 Codership Oy <http://www.codership.com>
+/* Copyright 2008-2015 Codership Oy <http://www.codership.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -20,6 +20,7 @@
 #include <sql_class.h>
 #include "wsrep_mysqld.h"
 #include "wsrep_binlog.h"
+#include "wsrep_xid.h"
 #include <cstdio>
 #include <cstdlib>
 
@@ -497,7 +498,7 @@ wsrep_run_wsrep_commit(THD *thd, handlerton *hton, bool all)
     if (thd->transaction.xid_state.xid.get_my_xid())
     {
       wsrep_xid_init(&thd->transaction.xid_state.xid,
-                     &thd->wsrep_trx_meta.gtid.uuid,
+                     thd->wsrep_trx_meta.gtid.uuid,
                      thd->wsrep_trx_meta.gtid.seqno);
     }
     DBUG_PRINT("wsrep", ("replicating commit success"));

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1,4 +1,4 @@
-/* Copyright 2008-2013 Codership Oy <http://www.codership.com>
+/* Copyright 2008-2015 Codership Oy <http://www.codership.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -23,6 +23,7 @@
 #include "wsrep_var.h"
 #include "wsrep_binlog.h"
 #include "wsrep_applier.h"
+#include "wsrep_xid.h"
 #include <cstdio>
 #include <cstdlib>
 #include "log_event.h"
@@ -150,66 +151,6 @@ static void wsrep_log_states (wsrep_log_level_t   const level,
             uuid_str, (long long)node_seqno);
   wsrep_log_cb (level, msg);
 }
-
-static my_bool set_SE_checkpoint(THD* unused, plugin_ref plugin, void* arg)
-{
-  XID* xid= reinterpret_cast<XID*>(arg);
-  handlerton* hton= plugin_data(plugin, handlerton *);
-  if (hton->db_type == DB_TYPE_INNODB)
-  {
-    const wsrep_uuid_t* uuid(wsrep_xid_uuid(xid));
-    char uuid_str[40] = {0, };
-    wsrep_uuid_print(uuid, uuid_str, sizeof(uuid_str));
-    WSREP_DEBUG("Set WSREPXid for InnoDB:  %s:%lld",
-                uuid_str, (long long)wsrep_xid_seqno(xid));
-    hton->wsrep_set_checkpoint(hton, xid);
-  }
-  return FALSE;
-}
-
-void wsrep_set_SE_checkpoint(XID* xid)
-{
-  plugin_foreach(NULL, set_SE_checkpoint, MYSQL_STORAGE_ENGINE_PLUGIN, xid);
-}
-
-static my_bool get_SE_checkpoint(THD* unused, plugin_ref plugin, void* arg)
-{
-  XID* xid= reinterpret_cast<XID*>(arg);
-  handlerton* hton= plugin_data(plugin, handlerton *);
-  if (hton->db_type == DB_TYPE_INNODB)
-  {
-    hton->wsrep_get_checkpoint(hton, xid);
-    const wsrep_uuid_t* uuid(wsrep_xid_uuid(xid));
-    char uuid_str[40] = {0, };
-    wsrep_uuid_print(uuid, uuid_str, sizeof(uuid_str));
-    WSREP_DEBUG("Read WSREPXid from InnoDB:  %s:%lld",
-                uuid_str, (long long)wsrep_xid_seqno(xid));
-
-  }
-  return FALSE;
-}
-
-void wsrep_get_SE_checkpoint(XID* xid)
-{
-  plugin_foreach(NULL, get_SE_checkpoint, MYSQL_STORAGE_ENGINE_PLUGIN, xid);
-}
-
-void wsrep_init_sidno(const wsrep_uuid_t& uuid)
-{
-  /* generate new Sid map entry from inverted uuid */
-  rpl_sid sid;
-  wsrep_uuid_t ltid_uuid;
-  for (size_t i= 0; i < sizeof(ltid_uuid.data); ++i)
-  {
-      ltid_uuid.data[i] = ~local_uuid.data[i];
-  }
-  sid.copy_from(ltid_uuid.data);
-  global_sid_lock->wrlock();
-  wsrep_sidno= global_sid_map->add_sid(sid);
-  WSREP_INFO("inited wsrep sidno %d", wsrep_sidno);
-  global_sid_lock->unlock();
-}
-
 
 static wsrep_cb_status_t
 wsrep_view_handler_cb (void*                    app_ctx,
@@ -341,11 +282,9 @@ wsrep_view_handler_cb (void*                    app_ctx,
         local_seqno= view->state_id.seqno;
       }
       /* Init storage engine XIDs from first view */
-      XID xid;
-      wsrep_xid_init(&xid, &local_uuid, local_seqno);
-      wsrep_set_SE_checkpoint(&xid);
-      new_status= WSREP_MEMBER_JOINED;
+      wsrep_set_SE_checkpoint(local_uuid, local_seqno);
       wsrep_init_sidno(local_uuid);
+      new_status= WSREP_MEMBER_JOINED;
     }
 
     // just some sanity check
@@ -453,38 +392,28 @@ static void wsrep_synced_cb(void* app_ctx)
 static void wsrep_init_position()
 {
   /* read XIDs from storage engines */
-  XID xid;
-  memset(&xid, 0, sizeof(xid));
-  xid.formatID= -1;
-  wsrep_get_SE_checkpoint(&xid);
+  wsrep_uuid_t uuid;
+  wsrep_seqno_t seqno;
+  wsrep_get_SE_checkpoint(uuid, seqno);
 
-  if (xid.formatID == -1)
+  if (!memcmp(&uuid, &WSREP_UUID_UNDEFINED, sizeof(wsrep_uuid_t)))
   {
     WSREP_INFO("Read nil XID from storage engines, skipping position init");
     return;
   }
-  else if (!wsrep_is_wsrep_xid(&xid))
-  {
-    WSREP_WARN("Read non-wsrep XID from storage engines, skipping position init");
-    return;
-  }
-
-  const wsrep_uuid_t* uuid= wsrep_xid_uuid(&xid);
-  const wsrep_seqno_t seqno= wsrep_xid_seqno(&xid);
 
   char uuid_str[40] = {0, };
-  wsrep_uuid_print(uuid, uuid_str, sizeof(uuid_str));
+  wsrep_uuid_print(&uuid, uuid_str, sizeof(uuid_str));
   WSREP_INFO("Initial position: %s:%lld", uuid_str, (long long)seqno);
-
 
   if (!memcmp(&local_uuid, &WSREP_UUID_UNDEFINED, sizeof(local_uuid)) &&
       local_seqno == WSREP_SEQNO_UNDEFINED)
   {
     // Initial state
-    local_uuid= *uuid;
+    local_uuid= uuid;
     local_seqno= seqno;
   }
-  else if (memcmp(&local_uuid, uuid, sizeof(local_uuid)) ||
+  else if (memcmp(&local_uuid, &uuid, sizeof(local_uuid)) ||
            local_seqno != seqno)
   {
     WSREP_WARN("Initial position was provided by configuration or SST, "
@@ -730,14 +659,12 @@ void wsrep_recover()
                uuid_str, (long long)local_seqno);
     return;
   }
-  XID xid;
-  memset(&xid, 0, sizeof(xid));
-  xid.formatID= -1;
-  wsrep_get_SE_checkpoint(&xid);
+  wsrep_uuid_t uuid;
+  wsrep_seqno_t seqno;
+  wsrep_get_SE_checkpoint(uuid, seqno);
   char uuid_str[40];
-  wsrep_uuid_print(wsrep_xid_uuid(&xid), uuid_str, sizeof(uuid_str));
-  WSREP_INFO("Recovered position: %s:%lld", uuid_str,
-             (long long)wsrep_xid_seqno(&xid));
+  wsrep_uuid_print(&uuid, uuid_str, sizeof(uuid_str));
+  WSREP_INFO("Recovered position: %s:%lld", uuid_str, (long long)seqno);
 }
 
 
@@ -1313,11 +1240,9 @@ static void wsrep_TOI_end(THD *thd) {
 
   WSREP_DEBUG("TO END: %lld, %d : %s", (long long)wsrep_thd_trx_seqno(thd),
               thd->wsrep_exec_mode, (thd->query()) ? thd->query() : "void");
-  
-  XID xid;
-  wsrep_xid_init(&xid, &thd->wsrep_trx_meta.gtid.uuid,
-                 thd->wsrep_trx_meta.gtid.seqno);
-  wsrep_set_SE_checkpoint(&xid);
+
+  wsrep_set_SE_checkpoint(thd->wsrep_trx_meta.gtid.uuid,
+                          thd->wsrep_trx_meta.gtid.seqno);
   WSREP_DEBUG("TO END: %lld, update seqno",
               (long long)wsrep_thd_trx_seqno(thd));
   

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -1,4 +1,4 @@
-/* Copyright 2008-2013 Codership Oy <http://www.codership.com>
+/* Copyright 2008-2015 Codership Oy <http://www.codership.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -309,13 +309,5 @@ int wsrep_create_trigger_query(THD *thd, uchar** buf, size_t* buf_len);
 int wsrep_create_event_query(THD *thd, uchar** buf, size_t* buf_len);
 int wsrep_alter_event_query(THD *thd, uchar** buf, size_t* buf_len);
 
-struct xid_t;
-void wsrep_get_SE_checkpoint(xid_t*);
-void wsrep_set_SE_checkpoint(xid_t*);
-void wsrep_init_sidno(const wsrep_uuid_t&);
-void wsrep_xid_init(xid_t*, const wsrep_uuid_t*, wsrep_seqno_t);
-const wsrep_uuid_t* wsrep_xid_uuid(const xid_t*);
-wsrep_seqno_t wsrep_xid_seqno(const xid_t*);
-int wsrep_is_wsrep_xid(const void* xid);
-
+bool wsrep_stmt_rollback_is_safe(THD* thd);
 #endif /* WSREP_MYSQLD_H */

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -1,4 +1,4 @@
-/* Copyright 2008-2012 Codership Oy <http://www.codership.com>
+/* Copyright 2008-2015 Codership Oy <http://www.codership.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -23,6 +23,7 @@
 #include <sql_parse.h>
 #include "wsrep_priv.h"
 #include "wsrep_utils.h"
+#include "wsrep_xid.h"
 #include <cstdio>
 #include <cstdlib>
 
@@ -253,7 +254,23 @@ void wsrep_sst_received (wsrep_t*            const wsrep,
     wsrep_gtid_t const state_id = {
         *uuid, (rcode ? WSREP_SEQNO_UNDEFINED : seqno)
     };
-    wsrep_init_sidno(state_id.uuid);
+
+    wsrep_uuid_t current_uuid;
+    wsrep_seqno_t current_seqno;
+    wsrep_get_SE_checkpoint(current_uuid, current_seqno);
+
+    if (memcmp(&current_uuid, &state_id.uuid, sizeof(wsrep_uuid_t)) ||
+        current_seqno < state_id.seqno)
+    {
+        wsrep_set_SE_checkpoint(state_id.uuid, state_id.seqno);
+        wsrep_init_sidno(state_id.uuid);
+    }
+    else
+    {
+        // we should not be receiving SSTs in the past...
+        assert(current_seqno == state_id.seqno);
+    }
+
     wsrep->sst_received(wsrep, &state_id, state, state_len, rcode);
 }
 

--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -1,4 +1,4 @@
-/* Copyright 2010 Codership Oy <http://www.codership.com>
+/* Copyright 2010-2015 Codership Oy <http://www.codership.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -466,59 +466,4 @@ size_t wsrep_guess_ip (char* buf, size_t buf_len)
 #endif // HAVE_GETIFADDRS
 
   return 0;
-}
-
-/*
- * WSREPXid
- */
-
-#define WSREP_XID_PREFIX "WSREPXid"
-#define WSREP_XID_PREFIX_LEN MYSQL_XID_PREFIX_LEN
-#define WSREP_XID_UUID_OFFSET 8
-#define WSREP_XID_SEQNO_OFFSET (WSREP_XID_UUID_OFFSET + sizeof(wsrep_uuid_t))
-#define WSREP_XID_GTRID_LEN (WSREP_XID_SEQNO_OFFSET + sizeof(wsrep_seqno_t))
-
-void wsrep_xid_init(XID* xid, const wsrep_uuid_t* uuid, wsrep_seqno_t seqno)
-{
-  xid->formatID= 1;
-  xid->gtrid_length= WSREP_XID_GTRID_LEN;
-  xid->bqual_length= 0;
-  memset(xid->data, 0, sizeof(xid->data));
-  memcpy(xid->data, WSREP_XID_PREFIX, WSREP_XID_PREFIX_LEN);
-  memcpy(xid->data + WSREP_XID_UUID_OFFSET, uuid, sizeof(wsrep_uuid_t));
-  memcpy(xid->data + WSREP_XID_SEQNO_OFFSET, &seqno, sizeof(wsrep_seqno_t));
-}
-
-const wsrep_uuid_t* wsrep_xid_uuid(const XID* xid)
-{
-  if (wsrep_is_wsrep_xid(xid))
-    return reinterpret_cast<const wsrep_uuid_t*>(xid->data
-                                                 + WSREP_XID_UUID_OFFSET);
-  else
-    return &WSREP_UUID_UNDEFINED;
-}
-
-wsrep_seqno_t wsrep_xid_seqno(const XID* xid)
-{
-
-  if (wsrep_is_wsrep_xid(xid))
-  {
-    wsrep_seqno_t seqno;
-    memcpy(&seqno, xid->data + WSREP_XID_SEQNO_OFFSET, sizeof(wsrep_seqno_t));
-    return seqno;
-  }
-  else
-  {
-    return WSREP_SEQNO_UNDEFINED;
-  }
-}
-
-extern
-int wsrep_is_wsrep_xid(const void* xid_ptr)
-{
-  const XID* xid= reinterpret_cast<const XID*>(xid_ptr);
-  return (xid->formatID      == 1                   &&
-          xid->gtrid_length  == WSREP_XID_GTRID_LEN &&
-          xid->bqual_length  == 0                   &&
-          !memcmp(xid->data, WSREP_XID_PREFIX, WSREP_XID_PREFIX_LEN));
 }

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -1,4 +1,4 @@
-/* Copyright 2008 Codership Oy <http://www.codership.com>
+/* Copyright 2008-2015 Codership Oy <http://www.codership.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@
 #include <sql_acl.h>
 #include "wsrep_priv.h"
 #include "wsrep_thd.h"
+#include "wsrep_xid.h"
 #include <my_dir.h>
 #include <cstdio>
 #include <cstdlib>
@@ -150,12 +151,9 @@ void wsrep_set_local_position (const char* value)
 {
   size_t value_len  = strlen (value);
   size_t uuid_len   = wsrep_uuid_scan (value, value_len, &local_uuid);
+  local_seqno       = strtoll (value + uuid_len + 1, NULL, 10);
 
-  local_seqno = strtoll (value + uuid_len + 1, NULL, 10);
-
-  XID xid;
-  wsrep_xid_init(&xid, &local_uuid, local_seqno);
-  wsrep_set_SE_checkpoint(&xid);
+  wsrep_set_SE_checkpoint(local_uuid, local_seqno);
   WSREP_INFO ("wsrep_start_position var submitted: '%s'", wsrep_start_position);
 }
 

--- a/sql/wsrep_xid.cc
+++ b/sql/wsrep_xid.cc
@@ -1,0 +1,169 @@
+/* Copyright 2015 Codership Oy <http://www.codership.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+//! @file some utility functions and classes not directly related to replication
+
+#include "wsrep_xid.h"
+#include "sql_class.h"
+#include "wsrep_mysqld.h" // for logging macros
+
+/*
+ * WSREPXid
+ */
+
+#define WSREP_XID_PREFIX "WSREPXid"
+#define WSREP_XID_PREFIX_LEN MYSQL_XID_PREFIX_LEN
+#define WSREP_XID_UUID_OFFSET 8
+#define WSREP_XID_SEQNO_OFFSET (WSREP_XID_UUID_OFFSET + sizeof(wsrep_uuid_t))
+#define WSREP_XID_GTRID_LEN (WSREP_XID_SEQNO_OFFSET + sizeof(wsrep_seqno_t))
+
+void wsrep_xid_init(XID* xid, const wsrep_uuid_t& uuid, wsrep_seqno_t seqno)
+{
+  xid->formatID= 1;
+  xid->gtrid_length= WSREP_XID_GTRID_LEN;
+  xid->bqual_length= 0;
+  memset(xid->data, 0, sizeof(xid->data));
+  memcpy(xid->data, WSREP_XID_PREFIX, WSREP_XID_PREFIX_LEN);
+  memcpy(xid->data + WSREP_XID_UUID_OFFSET,  &uuid,  sizeof(wsrep_uuid_t));
+  memcpy(xid->data + WSREP_XID_SEQNO_OFFSET, &seqno, sizeof(wsrep_seqno_t));
+}
+
+inline
+int wsrep_is_wsrep_xid(const void* xid_ptr)
+{
+  const XID* xid= reinterpret_cast<const XID*>(xid_ptr);
+  return (xid->formatID      == 1                   &&
+          xid->gtrid_length  == WSREP_XID_GTRID_LEN &&
+          xid->bqual_length  == 0                   &&
+          !memcmp(xid->data, WSREP_XID_PREFIX, WSREP_XID_PREFIX_LEN));
+}
+
+const wsrep_uuid_t* wsrep_xid_uuid(const XID& xid)
+{
+  if (wsrep_is_wsrep_xid(&xid))
+    return reinterpret_cast<const wsrep_uuid_t*>(xid.data
+                                                 + WSREP_XID_UUID_OFFSET);
+  else
+    return &WSREP_UUID_UNDEFINED;
+}
+
+wsrep_seqno_t wsrep_xid_seqno(const XID& xid)
+{
+  if (wsrep_is_wsrep_xid(&xid))
+  {
+    wsrep_seqno_t seqno;
+    memcpy(&seqno, xid.data + WSREP_XID_SEQNO_OFFSET, sizeof(wsrep_seqno_t));
+    return seqno;
+  }
+  else
+  {
+    return WSREP_SEQNO_UNDEFINED;
+  }
+}
+
+static my_bool set_SE_checkpoint(THD* unused, plugin_ref plugin, void* arg)
+{
+  XID* xid= static_cast<XID*>(arg);
+  handlerton* hton= plugin_data(plugin, handlerton *);
+
+  if (hton->db_type == DB_TYPE_INNODB)
+  {
+    const wsrep_uuid_t* uuid(wsrep_xid_uuid(*xid));
+    char uuid_str[40] = {0, };
+    wsrep_uuid_print(uuid, uuid_str, sizeof(uuid_str));
+    WSREP_DEBUG("Set WSREPXid for InnoDB:  %s:%lld",
+                uuid_str, (long long)wsrep_xid_seqno(*xid));
+    hton->wsrep_set_checkpoint(hton, xid);
+  }
+
+  return FALSE;
+}
+
+void wsrep_set_SE_checkpoint(XID& xid)
+{
+  plugin_foreach(NULL, set_SE_checkpoint, MYSQL_STORAGE_ENGINE_PLUGIN, &xid);
+}
+
+void wsrep_set_SE_checkpoint(const wsrep_uuid_t& uuid, wsrep_seqno_t seqno)
+{
+  XID xid;
+  wsrep_xid_init(&xid, uuid, seqno);
+  wsrep_set_SE_checkpoint(xid);
+}
+
+static my_bool get_SE_checkpoint(THD* unused, plugin_ref plugin, void* arg)
+{
+  XID* xid= reinterpret_cast<XID*>(arg);
+  handlerton* hton= plugin_data(plugin, handlerton *);
+
+  if (hton->db_type == DB_TYPE_INNODB)
+  {
+    hton->wsrep_get_checkpoint(hton, xid);
+    const wsrep_uuid_t* uuid(wsrep_xid_uuid(*xid));
+    char uuid_str[40] = {0, };
+    wsrep_uuid_print(uuid, uuid_str, sizeof(uuid_str));
+    WSREP_DEBUG("Read WSREPXid from InnoDB:  %s:%lld",
+                uuid_str, (long long)wsrep_xid_seqno(*xid));
+  }
+
+  return FALSE;
+}
+
+void wsrep_get_SE_checkpoint(XID& xid)
+{
+  plugin_foreach(NULL, get_SE_checkpoint, MYSQL_STORAGE_ENGINE_PLUGIN, &xid);
+}
+
+void wsrep_get_SE_checkpoint(wsrep_uuid_t& uuid, wsrep_seqno_t& seqno)
+{
+  uuid= WSREP_UUID_UNDEFINED;
+  seqno= WSREP_SEQNO_UNDEFINED;
+
+  XID xid;
+  memset(&xid, 0, sizeof(xid));
+  xid.formatID= -1;
+
+  wsrep_get_SE_checkpoint(xid);
+
+  if (xid.formatID == -1) return; // nil XID
+
+  if (!wsrep_is_wsrep_xid(&xid))
+  {
+    WSREP_WARN("Read non-wsrep XID from storage engines.");
+    return;
+  }
+
+  uuid= *wsrep_xid_uuid(xid);
+  seqno= wsrep_xid_seqno(xid);
+}
+
+void wsrep_init_sidno(const wsrep_uuid_t& wsrep_uuid)
+{
+  /* generate new Sid map entry from inverted uuid */
+  rpl_sid sid;
+  wsrep_uuid_t ltid_uuid;
+
+  for (size_t i= 0; i < sizeof(ltid_uuid.data); ++i)
+  {
+      ltid_uuid.data[i] = ~wsrep_uuid.data[i];
+  }
+
+  sid.copy_from(ltid_uuid.data);
+  global_sid_lock->wrlock();
+  wsrep_sidno= global_sid_map->add_sid(sid);
+  WSREP_INFO("Initialized wsrep sidno %d", wsrep_sidno);
+  global_sid_lock->unlock();
+}

--- a/sql/wsrep_xid.h
+++ b/sql/wsrep_xid.h
@@ -1,0 +1,33 @@
+/* Copyright (C) 2015 Codership Oy <info@codership.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
+
+#ifndef WSREP_XID_H
+#define WSREP_XID_H
+
+#include "../wsrep/wsrep_api.h"
+#include "handler.h" // XID typedef
+
+void wsrep_xid_init(xid_t*, const wsrep_uuid_t&, wsrep_seqno_t);
+int wsrep_is_wsrep_xid(const void* xid);
+const wsrep_uuid_t* wsrep_xid_uuid(const XID&);
+wsrep_seqno_t wsrep_xid_seqno(const XID&);
+
+//void wsrep_get_SE_checkpoint(XID&); uncomment if needed
+void wsrep_get_SE_checkpoint(wsrep_uuid_t&, wsrep_seqno_t&);
+//void wsrep_set_SE_checkpoint(XID&); uncomment if needed
+void wsrep_set_SE_checkpoint(const wsrep_uuid_t&, wsrep_seqno_t);
+void wsrep_init_sidno(const wsrep_uuid_t&);
+
+#endif /* WSREP_UTILS_H */


### PR DESCRIPTION
1. factored XID-related functions to a separate wsrep_xid.cc unit.
2. refactored them to take refrences instead of pointers where appropriate
3. implemented wsrep_get/set_SE_position to take wsrep_uuid_t and wsrep_seqno_t instead of XID
4. call wsrep_set_SE_position() in wsrep_sst_received() to reinitialize SE checkpoint after SST was received, avoid assert() in setting code by first checking current position.
