### PR TITLE
refs codership/mysql-wsrep#98 fixed sidno initialization

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -152,6 +152,24 @@ static void wsrep_log_states (wsrep_log_level_t   const level,
   wsrep_log_cb (level, msg);
 }
 
+void wsrep_init_sidno(const wsrep_uuid_t& wsrep_uuid)
+{
+  /* generate new Sid map entry from inverted uuid */
+  rpl_sid sid;
+  wsrep_uuid_t ltid_uuid;
+
+  for (size_t i= 0; i < sizeof(ltid_uuid.data); ++i)
+  {
+      ltid_uuid.data[i] = ~wsrep_uuid.data[i];
+  }
+
+  sid.copy_from(ltid_uuid.data);
+  global_sid_lock->wrlock();
+  wsrep_sidno= global_sid_map->add_sid(sid);
+  WSREP_INFO("Initialized wsrep sidno %d", wsrep_sidno);
+  global_sid_lock->unlock();
+}
+
 static wsrep_cb_status_t
 wsrep_view_handler_cb (void*                    app_ctx,
                        void*                    recv_ctx,

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -310,4 +310,7 @@ int wsrep_create_event_query(THD *thd, uchar** buf, size_t* buf_len);
 int wsrep_alter_event_query(THD *thd, uchar** buf, size_t* buf_len);
 
 bool wsrep_stmt_rollback_is_safe(THD* thd);
+
+void wsrep_init_sidno(const wsrep_uuid_t&);
+
 #endif /* WSREP_MYSQLD_H */

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -263,13 +263,14 @@ void wsrep_sst_received (wsrep_t*            const wsrep,
         current_seqno < state_id.seqno)
     {
         wsrep_set_SE_checkpoint(state_id.uuid, state_id.seqno);
-        wsrep_init_sidno(state_id.uuid);
     }
     else
     {
         // we should not be receiving SSTs in the past...
         assert(current_seqno == state_id.seqno);
     }
+
+    wsrep_init_sidno(state_id.uuid);
 
     wsrep->sst_received(wsrep, &state_id, state, state_len, rcode);
 }

--- a/sql/wsrep_xid.cc
+++ b/sql/wsrep_xid.cc
@@ -148,21 +148,3 @@ void wsrep_get_SE_checkpoint(wsrep_uuid_t& uuid, wsrep_seqno_t& seqno)
   uuid= *wsrep_xid_uuid(xid);
   seqno= wsrep_xid_seqno(xid);
 }
-
-void wsrep_init_sidno(const wsrep_uuid_t& wsrep_uuid)
-{
-  /* generate new Sid map entry from inverted uuid */
-  rpl_sid sid;
-  wsrep_uuid_t ltid_uuid;
-
-  for (size_t i= 0; i < sizeof(ltid_uuid.data); ++i)
-  {
-      ltid_uuid.data[i] = ~wsrep_uuid.data[i];
-  }
-
-  sid.copy_from(ltid_uuid.data);
-  global_sid_lock->wrlock();
-  wsrep_sidno= global_sid_map->add_sid(sid);
-  WSREP_INFO("Initialized wsrep sidno %d", wsrep_sidno);
-  global_sid_lock->unlock();
-}

--- a/sql/wsrep_xid.h
+++ b/sql/wsrep_xid.h
@@ -28,6 +28,5 @@ wsrep_seqno_t wsrep_xid_seqno(const XID&);
 void wsrep_get_SE_checkpoint(wsrep_uuid_t&, wsrep_seqno_t&);
 //void wsrep_set_SE_checkpoint(XID&); uncomment if needed
 void wsrep_set_SE_checkpoint(const wsrep_uuid_t&, wsrep_seqno_t);
-void wsrep_init_sidno(const wsrep_uuid_t&);
 
 #endif /* WSREP_UTILS_H */


### PR DESCRIPTION
Sidno initialization was skipped in wsrep_sst_received() if the
received position matched to current position. However, sidno
initialization must be done every time server is started to
add inverted group uuid into sidno map.

Also moved wsrep_init_sidno() from wsrep_xid.cc back to
wsrep_mysqld.cc as sidno and XID are not related.
