### PR TITLE
Removed unnecessary metapackages and unified with changes done in the 5.5 Debian packaging

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mysql-wsrep-5.6 (5.6.23-25.10-1) UNRELEASED; urgency=low
+
+  * Bumped version numbers
+
+ -- Otto Kekäläinen <otto@seravo.fi>  Thu, 26 Mar 2015 15:49:37 +0200
+
 mysql-wsrep-5.6 (5.6.21-25.6-1) UNRELEASED; urgency=low
 
   * Initial wsrep version

--- a/debian/control
+++ b/debian/control
@@ -1,10 +1,7 @@
 Source: mysql-wsrep-5.6
 Section: database
 Priority: optional
-Maintainer: Debian MySQL Maintainers <pkg-mysql-maint@lists.alioth.debian.org>
-Uploaders: Norbert Tretkowski <norbert@tretkowski.de>,
-           Clint Byrum <clint@ubuntu.com>,
-           James Page <jamespage@debian.org>
+Maintainer: Codership Oy <info@codership.com>
 Build-Depends: bison,
                chrpath,
                cmake,
@@ -22,10 +19,9 @@ Build-Depends: bison,
                psmisc,
                zlib1g-dev (>= 1:1.1.3-5)
 Standards-Version: 3.9.3
-Homepage: http://dev.mysql.com/
-Vcs-Git: git://git.debian.org/git/pkg-mysql/mysql-5.6.git
-Vcs-Browser: http://git.debian.org/?p=pkg-mysql/mysql-5.6.git
-XS-Testsuite: autopkgtest
+Homepage: http://galeracluster.com/
+Vcs-Git: https://github.com/codership/mysql-wsrep.git
+Vcs-Browser: https://github.com/codership/mysql-wsrep
 
 Package: mysql-wsrep-libmysqlclient18
 Section: libs
@@ -34,7 +30,6 @@ Depends: mysql-wsrep-common-5.6, ${misc:Depends}, ${shlibs:Depends}
 Pre-Depends: multiarch-support, ${misc:Pre-Depends}
 Replaces: libmysqlclient18
 Provides: libmysqlclient18
-Recommends: mysql-wsrep-common-5.6
 Multi-Arch: same
 Description: MySQL database client library
  MySQL is a fast, stable and true multi-user, multi-threaded SQL database
@@ -159,5 +154,6 @@ Description: MySQL 5.6 testsuite
 Package: mysql-wsrep-5.6
 Architecture: any
 Depends: mysql-wsrep-client-5.6 (= ${binary:Version}),
-         mysql-wsrep-server-5.6 (= ${binary:Version})
+         mysql-wsrep-server-5.6 (= ${binary:Version}),
+         ${misc:Depends}
 Description: Metapackage that installs mysql-wsrep client and server packages.

--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,7 @@ XS-Testsuite: autopkgtest
 Package: mysql-wsrep-libmysqlclient18
 Section: libs
 Architecture: any
-Depends: mysql-wsrep-common (>= 5.5), ${misc:Depends}, ${shlibs:Depends}
+Depends: mysql-wsrep-common-5.6, ${misc:Depends}, ${shlibs:Depends}
 Pre-Depends: multiarch-support, ${misc:Pre-Depends}
 Replaces: libmysqlclient18
 Provides: libmysqlclient18
@@ -43,13 +43,6 @@ Description: MySQL database client library
  ease of use.
  .
  This package includes the client library.
-
-Package: mysql-wsrep-libmysqlclient18-dbg
-Architecture: any
-Section: debug
-Priority: extra
-Depends: mysql-wsrep-libmysqlclient18 (= ${binary:Version}), ${misc:Depends}
-Description: MySQL database client library debugging symbols.
 
 Package: mysql-wsrep-libmysqlclient-dev
 Architecture: any
@@ -66,33 +59,20 @@ Description: MySQL database development files
  .
  This package includes development libraries and header files.
 
-Package: mysql-wsrep-common
+Package: mysql-wsrep-common-5.6
 Architecture: all
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Multi-Arch: foreign
-Provides: mysql-common
-Replaces: mysql-common
-Description: MySQL database common files, e.g. /etc/mysql/my.cnf
- MySQL is a fast, stable and true multi-user, multi-threaded SQL database
- server. SQL (Structured Query Language) is the most popular database query
- language in the world. The main goals of MySQL are speed, robustness and
- ease of use.
- .
- This package includes files needed by all versions of the client library,
- e.g. /etc/mysql/my.cnf.
-
-Package: mysql-wsrep-common-5.6
-Architecture: all
-Depends: mysql-wsrep-common, ${misc:Depends}, ${shlibs:Depends}
-Multi-Arch: foreign
-Provides: mysql-common-5.6
-Replaces: mysql-common-5.6
-Breaks: mysql-common-5.5, mysql-common-5.6
+Provides: mysql-common, mysql-common-5.6
+Replaces: mysql-common, mysql-common-5.6
 Description: MySQL 5.6 specific common files, e.g. /etc/mysql/conf.d/my-5.6.cnf
  MySQL is a fast, stable and true multi-user, multi-threaded SQL database
  server. SQL (Structured Query Language) is the most popular database query
  language in the world. The main goals of MySQL are speed, robustness and
  ease of use.
+ .
+ This package also includes files needed by all versions of the client library,
+ e.g. /etc/mysql/my.cnf.
 
 Package: mysql-wsrep-client-5.6
 Architecture: any
@@ -100,15 +80,22 @@ Depends: debianutils (>=1.6),
          libdbd-mysql-perl (>= 1.2202),
          libdbi-perl,
          libterm-readkey-perl,
-         mysql-wsrep-common (>= 5.5),
+         mysql-wsrep-common-5.6,
          mysql-wsrep-libmysqlclient18,
          ${misc:Depends},
          ${perl:Depends},
          ${shlibs:Depends}
-Recommends: mysql-wsrep-common-5.6
 Provides: virtual-mysql-client
-Breaks: mysql-client-5.5, mysql-client-5.6, mysql-client-core-5.5, mysql-client-core-5.6, virtual-mysql-client
-Replaces: mysql-client-5.5, mysql-client-5.6, mysql-client-core-5.5, mysql-client-core-5.6, virtual-mysql-client
+Breaks: mysql-client-5.5,
+        mysql-client-5.6,
+        mysql-client-core-5.5,
+        mysql-client-core-5.6,
+        virtual-mysql-client
+Replaces: mysql-client-5.5,
+          mysql-client-5.6,
+          mysql-client-core-5.5,
+          mysql-client-core-5.6,
+          virtual-mysql-client
 Description: MySQL database client binaries
  MySQL is a fast, stable and true multi-user, multi-threaded SQL database
  server. SQL (Structured Query Language) is the most popular database query
@@ -118,33 +105,30 @@ Description: MySQL database client binaries
  This package includes the client binaries and the additional tools
  innotop and mysqlreport.
 
-Package: mysql-wsrep-client-5.6-dbg
-Architecture: any
-Section: debug
-Priority: extra
-Depends: mysql-wsrep-client-5.6 (= ${binary:Version}), ${misc:Depends}
-Description: MySQL database client binary debugging symbols.
-
 Package: mysql-wsrep-server-5.6
 Architecture: any
-Recommends: libhtml-template-perl, mysql-wsrep-common-5.6
+Recommends: libhtml-template-perl
 Suggests: mailx, tinyca
-Pre-Depends: adduser (>= 3.40), debconf, mysql-wsrep-common (>= 5.5)
+Pre-Depends: adduser (>= 3.40), debconf, mysql-wsrep-common-5.6
 Depends: initscripts,
          libdbi-perl,
          lsb-base (>= 3.0-10),
+         lsof,
          mysql-wsrep-client-5.6 (>= ${binary:Version}),
          passwd,
          perl (>= 5.6),
          psmisc,
-         socat,
          rsync,
-         lsof,
+         socat,
          ${misc:Depends},
          ${shlibs:Depends}
 Provides: virtual-mysql-server
-Breaks: mysql-server-5.6, mysql-server-5.5, mysql-server-core-5.6, mysql-server-core-5.5, virtual-mysql-server
-Replaces: mysql-server-5.6, mysql-server-5.5,  virtual-mysql-server
+Breaks: mysql-server-5.5,
+        mysql-server-5.6,
+        mysql-server-core-5.5,
+        mysql-server-core-5.6,
+        virtual-mysql-server
+Replaces: mysql-server-5.5, mysql-server-5.6, virtual-mysql-server
 Description: MySQL database wsrep server binaries and system database setup
  MySQL is a fast, stable and true multi-user, multi-threaded SQL database
  server. SQL (Structured Query Language) is the most popular database query
@@ -154,47 +138,6 @@ Description: MySQL database wsrep server binaries and system database setup
  This package contains all the infrastructure needed to setup system
  databases.
 
-Package: mysql-wsrep-server-5.6-dbg
-Architecture: any
-Section: debug
-Priority: extra
-Depends: mysql-wsrep-client-5.6 (= ${binary:Version}), ${misc:Depends}
-Description: MySQL database wsrep server binary debugging symbols.
-
-Package: mysql-wsrep-server
-Architecture: all
-Depends: mysql-wsrep-server-5.6, ${misc:Depends}
-Description: MySQL database wsrep server (metapackage depending on the latest version)
- This is an empty package that depends on the current "best" version of
- mysql-wsrep-server (currently mysql-wsrep-server-5.6), as determined by the MySQL
- maintainers. Install this package if in doubt about which MySQL
- version you need. That will install the version recommended by the
- package maintainers.
- .
- MySQL is a fast, stable and true multi-user, multi-threaded SQL database
- server. SQL (Structured Query Language) is the most popular database query
- language in the world. The main goals of MySQL are speed, robustness and
- ease of use.
-
-Package: mysql-wsrep-client
-Architecture: all
-Depends: mysql-wsrep-client-5.6, ${misc:Depends}
-Description: MySQL database client (metapackage depending on the latest version)
- This is an empty package that depends on the current "best" version of
- mysql-wsrep-client (currently mysql-wsrep-client-5.6), as determined by the MySQL
- maintainers.  Install this package if in doubt about which MySQL version
- you want, as this is the one considered to be in the best shape by the
- Maintainers.
-
-Package: mysql-wsrep-testsuite
-Architecture: all
-Depends: mysql-testsuite-5.6, ${misc:Depends}
-Description: MySQL testsuite
- This is an empty package that depends on the current "best" version of
- mysql-testsuite (currently mysql-testsuite-5.6), as determined by the
- MySQL maintainers.  Install this package if in doubt about which MySQL
- version you want, as this is the one we consider to be in the best shape.
-
 Package: mysql-wsrep-testsuite-5.6
 Architecture: any
 Depends: mysql-wsrep-client-5.6 (= ${binary:Version}),
@@ -203,8 +146,8 @@ Depends: mysql-wsrep-client-5.6 (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}
 Provides: virtual-mysql-testsuite
-Breaks: mysql-testsuite-5.5, virtual-mysql-testsuite
-Replaces: mysql-testsuite-5.5, virtual-mysql-testsuite
+Breaks: mysql-testsuite-5.5, mysql-testsuite-5.6, virtual-mysql-testsuite
+Replaces: mysql-testsuite-5.5, mysql-testsuite-5.6, virtual-mysql-testsuite
 Description: MySQL 5.6 testsuite
  MySQL is a fast, stable, and true multi-user, multi-threaded SQL database
  server.  SQL (Structured Query Language) is the most popular database query

--- a/debian/mysql-wsrep-common-5.6.install
+++ b/debian/mysql-wsrep-common-5.6.install
@@ -1,1 +1,2 @@
+debian/additions/my.cnf etc/mysql/
 debian/additions/my5.6.cnf etc/mysql/conf.d/

--- a/debian/mysql-wsrep-common.install
+++ b/debian/mysql-wsrep-common.install
@@ -1,2 +1,0 @@
-debian/additions/my.cnf etc/mysql/
-debian/tmp/etc/mysql/conf.d/.keepme etc/mysql/conf.d

--- a/debian/rules
+++ b/debian/rules
@@ -220,9 +220,7 @@ override_dh_installcron-arch:
 	dh_installcron --name mysql-server
 
 override_dh_strip:
-	dh_strip --dbg-package=mysql-wsrep-server-5.6-dbg
-	dh_strip --dbg-package=mysql-wsrep-client-5.6-dbg
-	dh_strip --dbg-package=mysql-wsrep-libmysqlclient18-dbg
+	@echo "Notice: not stripping debug symbols from any binaries"
 
 binary:	binary-indep binary-arch
 


### PR DESCRIPTION
Test chain job#49 passed successfully and in e.g. in the Ubuntu test install job#211 you can see that the version number d710dc9 matches the latest commit in this pull request.
