### PR TITLE
d/rules: extend PATH to enable later use of ccache

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -61,7 +61,7 @@ ifneq ($(ARCH_OS),hurd)
 endif
 
 	( test -d $(builddir) || mkdir $(builddir) ) && cd $(builddir) && \
-	sh -c  'PATH=$${MYSQL_BUILD_PATH:-"/bin:/usr/bin"} \
+	sh -c  'PATH=$${MYSQL_BUILD_PATH:-"/usr/local/bin:/usr/bin:/bin"} \
 	    	CC=$${MYSQL_BUILD_CC:-gcc} \
 		CFLAGS=$${MYSQL_BUILD_CFLAGS:-"-O2 -DBIG_JOINS=1 ${FORCE_FPIC_CFLAGS} -fno-strict-aliasing"} \
 	    	CXX=$${MYSQL_BUILD_CXX:-g++} \


### PR DESCRIPTION
Similar change was done on 5.6 branch but due to fundamental
differences in the rules file that change could not be cherry-picked
