### PR TITLE
Fix Galera crash at startup when compiled with gcc 6

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -73,7 +73,7 @@ my_bool wsrep_slave_FK_checks          = 0; // slave thread does FK checks
  * End configuration options
  */
 
-static const wsrep_uuid_t cluster_uuid = WSREP_UUID_UNDEFINED;
+static wsrep_uuid_t cluster_uuid = WSREP_UUID_UNDEFINED;
 static char         cluster_uuid_str[40]= { 0, };
 static const char*  cluster_status_str[WSREP_VIEW_MAX] =
 {


### PR DESCRIPTION
Fix for issue codership/mysql-wsrep#267

With gcc 6.0, or when using gcc 5.x with -std=c++11, Galera
initialization crashes at mysql server startup.  This PR fixes an 
incorrect const qualifier in the code to prevent SIGSEGV.
