### PR TITLE
Treat log files always as text when parsing with grep

### DIFF
--- a/packaging/deb-in/extra/mysql-helpers
+++ b/packaging/deb-in/extra/mysql-helpers
@@ -80,7 +80,7 @@ get_recover_pos () {
     chown mysql.mysql $LOG
     /usr/sbin/mysqld --user=mysql --wsrep_recover --log-error=$LOG
 
-    local rp="$(grep 'WSREP: Recovered position:' $LOG | tail -n 1)"
+    local rp="$(grep -a 'WSREP: Recovered position:' $LOG | tail -n 1)"
     if [ -z "$rp" ]; then
          local skipped="$(grep WSREP $LOG | grep 'skipping position recovery')"
          if [ -z "$skipped" ]; then

--- a/scripts/systemd/mysqld_pre_systemd.in
+++ b/scripts/systemd/mysqld_pre_systemd.in
@@ -103,7 +103,7 @@ get_recover_pos () {
     @libexecdir@/mysqld ${instance:+--defaults-group-suffix=@$instance} \
                      --datadir="$datadir" --user=@MYSQLD_USER@ --wsrep_recover 2>> $log
 
-    local rp="$(grep 'WSREP: Recovered position:' $log | tail -n 1)"
+    local rp="$(grep -a 'WSREP: Recovered position:' $log | tail -n 1)"
     if [ -z "$rp" ]; then
          local skipped="$(grep WSREP $log | grep 'skipping position recovery')"
          if [ -z "$skipped" ]; then


### PR DESCRIPTION
This change enforces grep to always treat log files as text, preventing it from ever outputting "Binary file /var/log/mysql/error.log matches" as an argument to `wsrep_start_position`, which may happen when that `error.log` file contains null pointers. More details in #410 